### PR TITLE
build: allow pino v10 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
   },
   "peerDependencies": {
     "crawlee": "^3",
-    "pino": "^8 || ^9"
+    "pino": "^8 || ^9 || ^10"
   }
 }


### PR DESCRIPTION
The latest major of pino is 10. Allow it as a peer dependency.